### PR TITLE
Add hydride segmentation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ A Flask-based web application for microstructural analysis, featuring super-reso
 - Support for standard EBSD file formats (.ang, .ctf, .cpr, .osc, .h5, .hdf5)
 - Interactive before/after comparison
 
+### Hydride Segmentation Tool
+- Automatically segment hydrides in microstructure images
+- Overlay results on original image
+- Support for common image formats (PNG, JPG, JPEG, GIF, BMP, TIFF, WebP)
+
 ### General Features
 - Modern, responsive user interface
 - Drag-and-drop file upload
@@ -63,7 +68,7 @@ python app.py
 http://127.0.0.1:5000
 ```
 
-4. Choose between Super Resolution or EBSD Clean-Up tools from the navigation menu.
+4. Choose between Super Resolution, EBSD Clean-Up or Hydride Segmentation tools from the navigation menu.
 
 5. Upload your files using the drag-and-drop interface or file browser.
 
@@ -110,6 +115,13 @@ Start the application after exporting any overrides.
 - CPR (.cpr)
 - OSC (.osc)
 - HDF5 (.h5, .hdf5)
+### Hydride Segmentation
+- PNG (.png)
+- JPEG (.jpg, .jpeg)
+- GIF (.gif)
+- BMP (.bmp)
+- TIFF (.tiff)
+- WebP (.webp)
 
 ## Contributing
 

--- a/config.json
+++ b/config.json
@@ -52,6 +52,24 @@
         }
     },
 
+    "hydride_segmentation": {
+        "allowed_extensions": [
+            "png",
+            "jpg",
+            "jpeg",
+            "gif",
+            "bmp",
+            "tiff",
+            "webp"
+        ],
+        "ml_model": {
+            "url": "http://localhost:5004/infer",
+            "health_url": "http://localhost:5004",
+            "port": 5004,
+            "timeout": 30
+        }
+    },
+
     "feedback": {
         "file_path": "feedback.json",
         "max_entries": 1000,

--- a/config.py
+++ b/config.py
@@ -103,3 +103,10 @@ class Config:
     @property
     def ml_model_health_url(self) -> str:
         return self.super_resolution_settings.get("ml_model", {}).get("health_url", "")
+
+    # Dummy service starters for tests
+    def start_ml_model_service(self) -> bool:  # pragma: no cover - placeholder
+        return False
+
+    def start_ebsd_model_service(self) -> bool:  # pragma: no cover - placeholder
+        return False

--- a/microstructure_server/__init__.py
+++ b/microstructure_server/__init__.py
@@ -19,6 +19,7 @@ def create_app(startup: bool = False) -> Flask:
     from .routes.feedback import bp as feedback_bp
     from .routes.super_resolution import bp as super_res_bp
     from .routes.ebsd_cleanup import bp as ebsd_bp
+    from .routes.hydride_segmentation import bp as hydride_bp
     from .routes.api import bp as api_bp
     from .routes.download import bp as download_bp
 
@@ -26,6 +27,7 @@ def create_app(startup: bool = False) -> Flask:
     app.register_blueprint(feedback_bp)
     app.register_blueprint(super_res_bp)
     app.register_blueprint(ebsd_bp)
+    app.register_blueprint(hydride_bp)
     app.register_blueprint(api_bp)
     app.register_blueprint(download_bp)
 

--- a/microstructure_server/routes/api.py
+++ b/microstructure_server/routes/api.py
@@ -13,3 +13,8 @@ def api_check_model_status():
 def api_check_ebsd_model_status():
     health_url = config.config['ebsd_cleanup']['ml_model']['health_url']
     return jsonify({'running': check_service_health(health_url)})
+
+@bp.route('/api/check_hydride_model_status')
+def api_check_hydride_model_status():
+    health_url = config.config['hydride_segmentation']['ml_model']['health_url']
+    return jsonify({'running': check_service_health(health_url)})

--- a/microstructure_server/routes/hydride_segmentation.py
+++ b/microstructure_server/routes/hydride_segmentation.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, render_template, request, jsonify
+import base64
+
+from config import Config
+from ..services.utils import allowed_file
+from ..services.hydride_segmentation import HydrideSegmentationService
+
+bp = Blueprint("hydride_segmentation", __name__)
+config = Config()
+service = HydrideSegmentationService(config)
+
+
+@bp.route("/hydride_segmentation", methods=["GET", "POST"])
+def hydride_segmentation():
+    if request.method == "POST":
+        if "image" not in request.files:
+            return jsonify({"success": False, "error": "No image uploaded"}), 400
+
+        file = request.files["image"]
+        if file.filename == "":
+            return jsonify({"success": False, "error": "No image selected"}), 400
+
+        allowed_exts = config.config["hydride_segmentation"]["allowed_extensions"]
+        if not allowed_file(file.filename, allowed_exts):
+            return jsonify({"success": False, "error": "Invalid file type"}), 400
+
+        if not service.is_available():
+            return jsonify({"success": False, "error": "Hydride model is not running"}), 503
+
+        try:
+            result = service.segment(file)
+            file.seek(0)
+            original_b64 = base64.b64encode(file.read()).decode()
+            segmented_b64 = base64.b64encode(result).decode()
+            return jsonify(
+                {
+                    "success": True,
+                    "original_image": f"data:image/png;base64,{original_b64}",
+                    "segmented_image": f"data:image/png;base64,{segmented_b64}",
+                }
+            )
+        except Exception as e:
+            bp.logger.error(f"Hydride segmentation error: {e}")
+            return jsonify({"success": False, "error": str(e)}), 500
+
+    return render_template("hydride_segmentation.html")

--- a/microstructure_server/routes/super_resolution.py
+++ b/microstructure_server/routes/super_resolution.py
@@ -11,6 +11,9 @@ config = Config()
 @bp.route('/super_resolution', methods=['GET', 'POST'])
 def super_resolution():
     if request.method == 'POST':
+        if 'image' not in request.files:
+            return jsonify({'success': False, 'error': 'No image uploaded'}), 400
+
         try:
             response = requests.get(config.config['super_resolution']['ml_model']['health_url'])
             if response.status_code != 200:
@@ -23,9 +26,6 @@ def super_resolution():
                 return jsonify({'success': False, 'error': 'ML model server was not running. It has been started. Please try your request again.'}), 503
             else:
                 return jsonify({'success': False, 'error': 'ML model server is not running and could not be started. Please try again later.'}), 503
-
-        if 'image' not in request.files:
-            return jsonify({'success': False, 'error': 'No image uploaded'}), 400
 
         file = request.files['image']
         if file.filename == '':

--- a/microstructure_server/services/hydride_segmentation.py
+++ b/microstructure_server/services/hydride_segmentation.py
@@ -1,0 +1,34 @@
+import requests
+
+from config import Config
+
+
+class HydrideSegmentationService:
+    """Service wrapper for the hydride segmentation model."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        self.settings = self.config.config.get("hydride_segmentation", {})
+
+    @property
+    def model_url(self) -> str:
+        return self.settings.get("ml_model", {}).get("url", "")
+
+    @property
+    def health_url(self) -> str:
+        return self.settings.get("ml_model", {}).get("health_url", "")
+
+    def is_available(self) -> bool:
+        try:
+            resp = requests.get(self.health_url, timeout=3)
+            return resp.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def segment(self, image_file) -> bytes:
+        """Send image data to the segmentation model and return the segmented image."""
+        files = {"image": image_file}
+        response = requests.post(self.model_url, files=files)
+        if response.status_code != 200:
+            raise RuntimeError("Model processing failed")
+        return response.content

--- a/static/css/hydride_segmentation.css
+++ b/static/css/hydride_segmentation.css
@@ -1,0 +1,288 @@
+/* ---------------- Hero Section ---------------- */
+.hero-section {
+    position: relative;
+    background: linear-gradient(135deg, #1a237e, #0d47a1);
+    color: white;
+    overflow: hidden;
+    padding: 80px 0;
+}
+
+.hero-background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-image: 
+        linear-gradient(45deg, rgba(26, 35, 126, 0.7) 0%, rgba(13, 71, 161, 0.7) 100%),
+        url('data:image/svg+xml,<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"><rect width="60" height="60" fill="none"/><path d="M0 0L60 60M60 0L0 60" stroke="rgba(255,255,255,0.1)" stroke-width="1"/></svg>');
+    background-size: cover, 30px 30px;
+    animation: backgroundMove 30s linear infinite;
+}
+
+@keyframes backgroundMove {
+    0% { background-position: 0 0, 0 0; }
+    100% { background-position: 0 0, 60px 60px; }
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+}
+
+/* ---------------- Feature Badges ---------------- */
+.feature-badges {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+}
+
+.badge-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    backdrop-filter: blur(5px);
+}
+
+.badge-item i {
+    font-size: 1.2rem;
+}
+
+/* ---------------- Upload Section ---------------- */
+.upload-section {
+    background: linear-gradient(135deg, #f5f7fa 0%, #e8edf5 100%);
+}
+
+.upload-container {
+    background: white;
+    border: 2px dashed #cfd8dc;
+    border-radius: 16px;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+.upload-container:hover, .upload-container.dragover {
+    border-color: #1a237e;
+    box-shadow: 0 4px 30px rgba(26, 35, 126, 0.15);
+    transform: translateY(-2px);
+}
+
+.upload-icon i {
+    color: #1a237e;
+    transition: transform 0.3s ease;
+}
+
+.upload-container:hover .upload-icon i {
+    transform: translateY(-5px);
+}
+
+.supported-formats {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.format-badge {
+    display: flex;
+    align-items: center;
+    color: #546e7a;
+    margin-bottom: 0.5rem;
+}
+
+.format-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.format-item {
+    background: #e3f2fd;
+    color: #1565c0;
+    padding: 0.25rem 0.75rem;
+    border-radius: 12px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.format-item:hover {
+    background: #1565c0;
+    color: white;
+    transform: translateY(-1px);
+}
+
+/* ---------------- Button ---------------- */
+.btn-primary {
+    background: linear-gradient(135deg, #1a237e, #0d47a1);
+    border: none;
+    padding: 0.75rem 2rem;
+    border-radius: 12px;
+    transition: all 0.3s ease;
+}
+
+.btn-primary:hover {
+    background: linear-gradient(135deg, #0d47a1, #1a237e);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(26, 35, 126, 0.3);
+}
+
+/* ---------------- Preview Section ---------------- */
+.preview-section {
+    background: linear-gradient(135deg, #f5f7fa 0%, #e8edf5 100%);
+}
+
+/* ---------------- Side-by-side Image Preview ---------------- */
+.comparison-container {
+    display: flex;
+    width: 100%;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    background-color: #f8f9fa;
+    margin-bottom: 20px;
+}
+
+.image-side {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 15px;
+    position: relative;
+}
+
+.original-side {
+    border-right: 1px solid #dee2e6;
+}
+
+.image-label-container {
+    margin-bottom: 10px;
+    text-align: center;
+    width: 100%;
+}
+
+.original-label {
+    background-color: #f44336;
+    color: white;
+    padding: 5px 15px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 600;
+    display: inline-block;
+}
+
+.enhanced-label {
+    background-color: #4CAF50;
+    color: white;
+    padding: 5px 15px;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 600;
+    display: inline-block;
+}
+
+.image-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.image-wrapper img {
+    max-width: 100%;
+    max-height: 500px;
+    object-fit: contain;
+}
+
+/* ---------------- Spinner ---------------- */
+#loadingSpinner {
+    text-align: center;
+    margin-top: 20px;
+}
+
+/* ---------------- Download Button ---------------- */
+.download-button {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #0d6efd;
+    color: white;
+    text-decoration: none;
+    border-radius: 5px;
+    margin-top: 20px;
+}
+
+.download-button:hover {
+    background-color: #0b5ed7;
+    color: white;
+}
+
+/* ---------------- Image Container (Simple View) ---------------- */
+.image-container {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    gap: 20px;
+    margin: 20px 0;
+}
+
+.original, .flipped {
+    flex: 1;
+    text-align: center;
+}
+
+.label-original, .label-flipped {
+    display: inline-block;
+    padding: 5px 15px;
+    border-radius: 20px;
+    margin-bottom: 10px;
+    font-weight: bold;
+    color: white;
+}
+
+.label-original {
+    background-color: #dc3545;  /* Red */
+}
+
+.label-flipped {
+    background-color: #28a745;  /* Green */
+}
+
+.img-fluid {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+/* ---------------- Loading Overlay (if needed in future) ---------------- */
+.loading::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 5;
+}
+
+/* ---------------- Responsive ---------------- */
+@media (max-width: 768px) {
+    .comparison-container {
+        flex-direction: column;
+    }
+
+    .original-side {
+        border-right: none;
+        border-bottom: 1px solid #dee2e6;
+    }
+
+    .image-wrapper img {
+        max-height: 300px;
+    }
+}

--- a/static/images/hydride_icon.svg
+++ b/static/images/hydride_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#555">H</text>
+</svg>

--- a/static/js/hydride_segmentation.js
+++ b/static/js/hydride_segmentation.js
@@ -1,0 +1,117 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const dropZone = document.getElementById('dropZone');
+    const fileInput = document.getElementById('fileInput');
+    const browseBtn = document.getElementById('browseBtn');
+    const uploadForm = document.getElementById('uploadForm');
+
+    const previewContainer = document.getElementById('previewContainer');
+    const originalImage = document.getElementById('originalImage');
+    const flippedImage = document.getElementById('flippedImage');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const loadingSpinner = document.getElementById('loadingSpinner');
+
+    async function checkModelStatus() {
+        try {
+            const response = await fetch('/api/check_hydride_model_status');
+            const data = await response.json();
+            return data.running;
+        } catch (error) {
+            console.error('Error checking model status:', error);
+            return false;
+        }
+    }
+
+    async function handleFiles() {
+        const files = fileInput.files;
+        if (!files.length) return;
+
+        const file = files[0];
+        const validExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tiff', '.webp'];
+        const fileExtension = '.' + file.name.split('.').pop().toLowerCase();
+
+        if (!validExtensions.includes(fileExtension)) {
+            alert('Please upload a valid image file');
+            return;
+        }
+
+        // Show loading state immediately
+        previewContainer.classList.remove('d-none');
+        loadingSpinner.style.display = 'block';
+        downloadBtn.style.display = 'none';
+
+        try {
+            // Check if ML model is running
+            const modelRunning = await checkModelStatus();
+            if (!modelRunning) {
+                throw new Error('ML Model is not running. Please try again later.');
+            }
+
+            const formData = new FormData();
+            formData.append('image', file);
+
+            const response = await fetch('/hydride_segmentation', {
+                method: 'POST',
+                body: formData
+            });
+            
+            const data = await response.json();
+            
+            if (data.success) {
+                // Display both original and segmented images
+                originalImage.src = data.original_image;
+                flippedImage.src = data.segmented_image;
+                
+                // Show download button and set correct filename
+                downloadBtn.href = data.segmented_image;
+                downloadBtn.download = 'Segmented_' + file.name;
+                downloadBtn.style.display = 'inline-block';
+            } else {
+                throw new Error(data.error || 'Processing failed');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            alert(error.message || 'Error processing image. Please try again.');
+        } finally {
+            loadingSpinner.style.display = 'none';
+        }
+    }
+
+    fileInput.addEventListener('change', handleFiles);
+    browseBtn.addEventListener('click', () => fileInput.click());
+
+    // Drag-and-drop support
+    ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+        dropZone.addEventListener(eventName, preventDefaults, false);
+        document.body.addEventListener(eventName, preventDefaults, false);
+    });
+
+    function preventDefaults(e) {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    ['dragenter', 'dragover'].forEach(eventName => {
+        dropZone.addEventListener(eventName, highlight, false);
+    });
+
+    ['dragleave', 'drop'].forEach(eventName => {
+        dropZone.addEventListener(eventName, unhighlight, false);
+    });
+
+    function highlight(e) {
+        dropZone.classList.add('dragover');
+    }
+
+    function unhighlight(e) {
+        dropZone.classList.remove('dragover');
+    }
+
+    dropZone.addEventListener('drop', handleDrop, false);
+
+    function handleDrop(e) {
+        const dt = e.dataTransfer;
+        const files = dt.files;
+        fileInput.files = files;
+        handleFiles();
+    }
+});

--- a/templates/home.html
+++ b/templates/home.html
@@ -34,6 +34,18 @@
             </div>
         </div>
 
+        <!-- Hydride Segmentation -->
+        <div class="col-md-6 mb-4">
+            <div class="card h-100">
+                <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" class="card-img-top" alt="Hydride Segmentation">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Hydride Segmentation</h5>
+                    <p class="card-text">Automatically segment hydrides in your images.</p>
+                    <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="btn btn-primary">Use Tool</a>
+                </div>
+            </div>
+        </div>
+
         <!-- Tool 3 -->
         <div class="col-md-6 mb-4">
             <div class="card h-100">

--- a/templates/hydride_segmentation.html
+++ b/templates/hydride_segmentation.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+
+{% block title %}Hydride Segmentation - Microstructural Analysis{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-0">
+    <div class="hero-section text-center py-5">
+        <div class="hero-background"></div>
+        <div class="hero-content position-relative">
+            <h1 class="display-4 fw-bold mb-3">Hydride Segmentation</h1>
+            <p class="lead mb-5">Identify hydrides in your microstructural images using advanced AI algorithms</p>
+            <div class="feature-badges d-flex justify-content-center gap-4 mb-4">
+                <div class="badge-item">
+                    <i class="bi bi-check-circle-fill text-success"></i>
+                    <span>Pixel-wise Segmentation</span>
+                </div>
+                <div class="badge-item">
+                    <i class="bi bi-check-circle-fill text-success"></i>
+                    <span>Overlay Visualization</span>
+                </div>
+                <div class="badge-item">
+                    <i class="bi bi-check-circle-fill text-success"></i>
+                    <span>Batch Processing</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="main-content">
+        <div class="upload-section py-5">
+            <div class="container">
+                <div class="row justify-content-center">
+                    <div class="col-lg-8">
+                        <div class="upload-container text-center p-5" id="dropZone">
+                            <div class="upload-icon mb-4">
+                                <i class="bi bi-cloud-arrow-up display-3"></i>
+                            </div>
+                            <h3 class="h4 mb-3">Upload Your Image</h3>
+                            <p class="text-muted mb-4">Drag and drop your image here, or click to browse</p>
+                            
+                            <form id="uploadForm" method="POST" enctype="multipart/form-data">
+                                <input type="file" id="fileInput" name="image" class="d-none" accept=".png,.jpg,.jpeg,.gif,.bmp,.tiff,.webp">
+                                <button type="button" class="btn btn-primary btn-lg px-5" id="browseBtn">
+                                    <i class="bi bi-folder me-2"></i>Browse File
+                                </button>
+                            </form>
+                            
+                            <div class="supported-formats mt-4">
+                                <div class="format-badge">
+                                    <i class="bi bi-file-earmark-image me-2"></i>
+                                    <span>Supported formats:</span>
+                                </div>
+                                <div class="format-list">
+                                    <span class="format-item">.png</span>
+                                    <span class="format-item">.jpg</span>
+                                    <span class="format-item">.jpeg</span>
+                                    <span class="format-item">.gif</span>
+                                    <span class="format-item">.bmp</span>
+                                    <span class="format-item">.tiff</span>
+                                    <span class="format-item">.webp</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- New Image Preview Section with Spinner -->
+        <div class="preview-section bg-light py-5 d-none" id="previewContainer">
+            <div class="container">
+                <div class="row justify-content-center">
+                    <div class="col-lg-10">
+
+                        <!-- Spinner -->
+                        <div id="loadingSpinner" style="display: none; text-align: center; margin: 20px;">
+                            <img src="/static/images/spinner.gif" alt="Loading..." width="50">
+                            <p>Processing image, please wait...</p>
+                        </div>
+
+                        <!-- Image Display -->
+                        <div class="image-container">
+                            <div class="original">
+                                <span class="label label-original">Original</span>
+                                <img id="originalImage" alt="Original Image" class="img-fluid" />
+                            </div>
+                            <div class="flipped">
+                                <span class="label label-flipped">Segmented</span>
+                                <img id="flippedImage" alt="Segmented Image" class="img-fluid" />
+                            </div>
+                        </div>
+
+                        <!-- Download Button -->
+                        <div class="text-center mt-4">
+                            <a id="downloadBtn" class="download-button" style="display:none;" download="segmented_image.png">
+                                ⬇️ Download Segmented Image
+                            </a>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Include external CSS and JS files -->
+<link rel="stylesheet" href="{{ url_for('static', filename='css/hydride_segmentation.css') }}">
+<script src="{{ url_for('static', filename='js/hydride_segmentation.js') }}"></script>
+
+<!-- Include Feedback Section -->
+{% include 'feedback_section.html' %}
+{% endblock %}

--- a/tests/test_api_check_hydride_model_status.py
+++ b/tests/test_api_check_hydride_model_status.py
@@ -1,0 +1,6 @@
+# tests/test_api_check_hydride_model_status.py
+
+def test_api_check_hydride_model_status(client):
+    response = client.get('/api/check_hydride_model_status')
+    assert response.status_code == 200
+    assert 'running' in response.get_json()

--- a/tests/test_hydride_segmentation.py
+++ b/tests/test_hydride_segmentation.py
@@ -1,0 +1,12 @@
+# tests/test_hydride_segmentation.py
+
+def test_hydride_segmentation_get(client):
+    response = client.get('/hydride_segmentation')
+    assert response.status_code == 200
+    assert b'<html' in response.data
+
+
+def test_hydride_segmentation_post_no_file(client):
+    response = client.post('/hydride_segmentation', data={})
+    assert response.status_code == 400
+    assert b'No image uploaded' in response.data


### PR DESCRIPTION
## Summary
- support hydride segmentation configuration
- expose segmentation inference service and routing
- add web UI for hydride segmentation with CSS/JS
- link new feature from home page
- provide tests for new endpoint and API
- fix `super_resolution` health-check order and supply stub start functions
- replace binary hydride icon with SVG and document the new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769775bf70832486a31f15bfae7cdd