### PR TITLE
Add mocked ML endpoint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,12 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from microstructure_server import create_app
+from config import Config
 
 @pytest.fixture
 def client():
+    os.environ['APP_LOGGING__LOG_DIR'] = os.path.join('tmp', 'test_logs')
+    Config._instance = None
     app = create_app()
     app.config['TESTING'] = True
     with app.test_client() as client:

--- a/tests/test_ebsd_cleanup.py
+++ b/tests/test_ebsd_cleanup.py
@@ -1,5 +1,7 @@
 # tests/test_ebsd_cleanup.py
 import io
+from unittest.mock import Mock
+from microstructure_server.routes import ebsd_cleanup as ec
 
 def test_ebsd_cleanup_get(client):
     response = client.get('/ebsd_cleanup')
@@ -10,3 +12,22 @@ def test_ebsd_cleanup_post_no_file(client):
     response = client.post('/ebsd_cleanup', data={})
     assert response.status_code == 400
     assert b'No EBSD file uploaded' in response.data
+
+
+def test_ebsd_cleanup_post_success(client, monkeypatch):
+    monkeypatch.setattr(ec.requests, 'get', lambda *a, **k: Mock(status_code=200))
+    monkeypatch.setattr(ec.requests, 'post', lambda *a, **k: Mock(status_code=200, json=lambda: {'success': True}))
+    data = {'ebsd_file': (io.BytesIO(b'file'), 'test.ang')}
+    response = client.post('/ebsd_cleanup', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert response.get_json()['success'] is True
+
+
+def test_ebsd_cleanup_health_failure(client, monkeypatch):
+    def raise_exc(*a, **k):
+        raise ec.requests.exceptions.RequestException('fail')
+
+    monkeypatch.setattr(ec.requests, 'get', raise_exc)
+    data = {'ebsd_file': (io.BytesIO(b'file'), 'test.ang')}
+    response = client.post('/ebsd_cleanup', data=data, content_type='multipart/form-data')
+    assert response.status_code == 503

--- a/tests/test_hydride_segmentation.py
+++ b/tests/test_hydride_segmentation.py
@@ -1,5 +1,7 @@
 # tests/test_hydride_segmentation.py
-
+import io
+from unittest.mock import Mock
+from microstructure_server.routes import hydride_segmentation as hs
 def test_hydride_segmentation_get(client):
     response = client.get('/hydride_segmentation')
     assert response.status_code == 200
@@ -10,3 +12,19 @@ def test_hydride_segmentation_post_no_file(client):
     response = client.post('/hydride_segmentation', data={})
     assert response.status_code == 400
     assert b'No image uploaded' in response.data
+
+
+def test_hydride_segmentation_success(client, monkeypatch):
+    monkeypatch.setattr(hs.service, 'is_available', lambda: True)
+    monkeypatch.setattr(hs.service, 'segment', lambda f: b'data')
+    data = {'image': (io.BytesIO(b'img'), 'img.png')}
+    response = client.post('/hydride_segmentation', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert response.get_json()['success'] is True
+
+
+def test_hydride_segmentation_unavailable(client, monkeypatch):
+    monkeypatch.setattr(hs.service, 'is_available', lambda: False)
+    data = {'image': (io.BytesIO(b'img'), 'img.png')}
+    response = client.post('/hydride_segmentation', data=data, content_type='multipart/form-data')
+    assert response.status_code == 503

--- a/tests/test_submit_feedback.py
+++ b/tests/test_submit_feedback.py
@@ -1,7 +1,13 @@
 # tests/test_submit_feedback.py
 import json
+import os
+from microstructure_server.routes import feedback as fb
 
-def test_submit_feedback_success(client):
+def test_submit_feedback_success(client, monkeypatch):
+    tmp_file = os.path.join('tmp', 'test_feedback.json')
+    monkeypatch.setattr(fb, 'FEEDBACK_FILE', tmp_file)
+    with open(tmp_file, 'w') as f:
+        json.dump({'feedback': []}, f)
     data = {
         'name': 'Test User',
         'email': 'test@example.com',
@@ -13,7 +19,8 @@ def test_submit_feedback_success(client):
     response_data = json.loads(response.data)
     assert response_data['success'] is True
 
-def test_submit_feedback_missing_fields(client):
+def test_submit_feedback_missing_fields(client, monkeypatch):
+    monkeypatch.setattr(fb, 'FEEDBACK_FILE', os.path.join('tmp', 'test_feedback.json'))
     data = {
         'name': 'Test User',
         'email': '',

--- a/tests/test_super_resolution.py
+++ b/tests/test_super_resolution.py
@@ -1,5 +1,8 @@
 # tests/test_super_resolution.py
 import io
+from unittest.mock import Mock
+from microstructure_server.routes import super_resolution as sr
+
 
 def test_super_resolution_get(client):
     response = client.get('/super_resolution')
@@ -10,3 +13,23 @@ def test_super_resolution_post_no_file(client):
     response = client.post('/super_resolution', data={})
     assert response.status_code == 400
     assert b'No image uploaded' in response.data
+
+
+def test_super_resolution_post_success(client, monkeypatch):
+    monkeypatch.setattr(sr.requests, 'get', lambda *a, **k: Mock(status_code=200))
+    monkeypatch.setattr(sr.requests, 'post', lambda *a, **k: Mock(status_code=200, content=b'data'))
+    data = {'image': (io.BytesIO(b'img'), 'test.png')}
+    response = client.post('/super_resolution', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    assert response.get_json()['success'] is True
+
+
+def test_super_resolution_health_failure(client, monkeypatch):
+    def raise_exc(*a, **k):
+        raise sr.requests.exceptions.RequestException('fail')
+
+    monkeypatch.setattr(sr.requests, 'get', raise_exc)
+    monkeypatch.setattr(sr.config, 'start_ml_model_service', lambda: False)
+    data = {'image': (io.BytesIO(b'img'), 'test.png')}
+    response = client.post('/super_resolution', data=data, content_type='multipart/form-data')
+    assert response.status_code == 503


### PR DESCRIPTION
## Summary
- mock network interactions using unittest.mock
- cover success & failure paths for super resolution, EBSD cleanup and hydride segmentation
- ensure feedback and log paths write under tmp during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f27effc48324a5621baf7d5e4c6d