### PR TITLE
Update home UI and navigation

### DIFF
--- a/src/ml_server/static/css/style.css
+++ b/src/ml_server/static/css/style.css
@@ -154,6 +154,42 @@ h1:after {
     margin-top: 2rem;
 }
 
+/* Icon Grid for Home Page */
+.icon-grid {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+
+.icon-link {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+    color: var(--text-color);
+    padding: 0.5rem;
+    border-radius: 12px;
+    transition: all 0.3s ease;
+}
+
+.icon-link:hover {
+    background-color: var(--light-gray);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.app-icon {
+    width: 100px;
+    height: 100px;
+    object-fit: contain;
+}
+
+.app-label {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    text-align: center;
+}
+
 .footer span {
     color: rgba(255, 255, 255, 0.9) !important;
     font-size: 0.9rem;

--- a/src/ml_server/templates/base.html
+++ b/src/ml_server/templates/base.html
@@ -20,12 +20,22 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('main.home') }}">
-                            <svg class='bi me-1' width='16' height='16'><use href='{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.svg') }}#house-door'/></svg>Home
+                            Home
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('main.help_faq') }}">
-                            <svg class='bi me-1' width='16' height='16'><use href='{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.svg') }}#question-circle'/></svg>Help & FAQ
+                        <a class="nav-link" href="{{ url_for('main.home') }}#about">
+                            About
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/docs">
+                            API Docs
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://github.com/kvmani/ml_server" target="_blank" rel="noopener noreferrer">
+                            GitHub
                         </a>
                     </li>
                 </ul>
@@ -67,25 +77,8 @@
     </div>
 
     <footer class="footer mt-5 py-4">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-6 text-center text-md-start">
-                    <span class="d-block mb-2">
-                        <svg class='bi me-2' width='16' height='16'><use href='{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.svg') }}#building'/></svg>
-                        Advanced Materials Research
-                    </span>
-                    <span class="d-block small">
-                        © 2024 All rights reserved.
-                    </span>
-                </div>
-                <div class="col-md-6 text-center text-md-end">
-                    <div class="research-links">
-                        <a href="#" class="text-white me-3">Privacy Policy</a>
-                        <a href="#" class="text-white me-3">Terms of Use</a>
-                        <a href="#" class="text-white">Research Guidelines</a>
-                    </div>
-                </div>
-            </div>
+        <div class="container text-center small">
+            Developed by Materials Group | Version 1.0 | © 2025
         </div>
     </footer>
 

--- a/src/ml_server/templates/home.html
+++ b/src/ml_server/templates/home.html
@@ -5,97 +5,31 @@
 {% block content %}
 <div class="container">
     <h1 class="text-center mb-4">Microstructural Analysis Tools</h1>
-    
-    <!-- Tools Grid -->
-    <div class="row justify-content-center">
-        <!-- Tool 1 -->
-        <div class="col-md-6 mb-4">
-            <div class="card h-100">
-                <!-- <img src="{{ url_for('static', filename='images/Microstructure-Super Resolution.png') }}" class="card-img-top" alt="Super Resolution"> -->
-                <img src="{{ url_for('static', filename='images/SUPER_RES.PNG') }}" class="card-img-top" alt="Super Resolution">
-                <div class="card-body text-center">
-                    <h5 class="card-title">Super Resolution</h5>
-                    <p class="card-text">Enhance the resolution of your microstructural images using advanced AI algorithms.</p>
-                    <a href="{{ url_for('super_resolution.super_resolution') }}" class="btn btn-primary">Use Tool</a>
-                </div>
-            </div>
-        </div>
 
-        <!-- Tool 2 -->
-        <div class="col-md-6 mb-4">
-            <div class="card h-100">
-                <!-- <img src="{{ url_for('static', filename='images/EBSD Clean-Up.png') }}" class="card-img-top" alt="EBSD Clean-Up"> -->
-                <img src="{{ url_for('static', filename='images/ebsd_icon.png') }}" class="card-img-top" alt="EBSD Clean-Up">
-                <div class="card-body text-center">
-                    <h5 class="card-title">EBSD Clean-Up</h5>
-                    <p class="card-text">Clean and process your EBSD data for better analysis and visualization.</p>
-                    <a href="{{ url_for('ebsd_cleanup.ebsd_cleanup') }}" class="btn btn-primary">Use Tool</a>
-                </div>
-            </div>
-        </div>
-
-        <!-- Hydride Segmentation -->
-        <div class="col-md-6 mb-4">
-            <div class="card h-100">
-                <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" class="card-img-top" alt="Hydride Segmentation">
-                <div class="card-body text-center">
-                    <h5 class="card-title">Hydride Segmentation</h5>
-                    <p class="card-text">Automatically segment hydrides in your images.</p>
-                    <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="btn btn-primary">Use Tool</a>
-                </div>
-            </div>
-        </div>
-
-        <!-- Tool 3 -->
-        <div class="col-md-6 mb-4">
-            <div class="card h-100">
-                <img src="{{ url_for('static', filename='images/APP3 Coming Soon.......png') }}" class="card-img-top" alt="Tool 3">
-                <div class="card-body text-center">
-                    <h5 class="card-title">Tool 3</h5>
-                    <p class="card-text">Coming soon - Stay tuned for more advanced microstructural analysis tools.</p>
-                    <button class="btn btn-secondary" disabled>Coming Soon</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Tool 4 -->
-        <div class="col-md-6 mb-4">
-            <div class="card h-100">
-                <img src="{{ url_for('static', filename='images/APP4 Coming Soon.......png') }}" class="card-img-top" alt="Tool 4">
-                <div class="card-body text-center">
-                    <h5 class="card-title">Tool 4</h5>
-                    <p class="card-text">Coming soon - Stay tuned for more advanced microstructural analysis tools.</p>
-                    <button class="btn btn-secondary" disabled>Coming Soon</button>
-                </div>
-            </div>
-        </div>
+    <!-- App Icon Grid -->
+    <div class="icon-grid">
+        <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="icon-link">
+            <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" alt="Hydride Segmentation" class="app-icon">
+            <span class="app-label">Hydride Segmentation</span>
+        </a>
+        <a href="{{ url_for('super_resolution.super_resolution') }}" class="icon-link">
+            <img src="{{ url_for('static', filename='images/SUPER_RES.PNG') }}" alt="Super-Resolution" class="app-icon">
+            <span class="app-label">Super-Resolution</span>
+        </a>
     </div>
 
-    <!-- About Us Section -->
-    <div class="about-section mt-5">
-        <h2 class="text-center mb-4">About Us</h2>
+    <!-- About Section -->
+    <div class="about-section mt-5" id="about">
+        <h2 class="text-center mb-4">About</h2>
         <div class="row">
             <div class="col-lg-8 mx-auto">
                 <div class="card">
                     <div class="card-body">
                         <p class="card-text">
-                            We are dedicated to advancing microstructural analysis through innovative tools and technologies. 
-                            Our platform provides researchers and scientists with powerful tools for analyzing and processing 
-                            microstructural data, making complex analysis more accessible and efficient.
-                        </p>
-                        <p class="card-text">
-                            Our suite of tools includes advanced features for:
-                        </p>
-                        <ul class="list-unstyled">
-                            <li>✓ High-resolution image enhancement</li>
-                            <li>✓ EBSD data processing and analysis</li>
-                            <li>✓ Advanced microstructural characterization</li>
-                            <li>✓ Data visualization and reporting</li>
-                        </ul>
-                        <p class="card-text">
-                            We continuously work on improving our tools and adding new features to meet the evolving needs 
-                            of the research community. Our commitment to excellence and innovation drives us to provide 
-                            the best possible solutions for microstructural analysis.
+                            This is an experimental intranet-deployed web service providing machine
+                            learning–based microstructure enhancement tools such as hydride segmentation
+                            and super-resolution. It uses CPU-only PyTorch models to enable efficient
+                            inference on edge devices or internal servers.
                         </p>
                     </div>
                 </div>
@@ -103,4 +37,4 @@
         </div>
     </div>
 </div>
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
## Summary
- trim homepage to show only active ML services
- rewrite about section
- add new navigation links and footer text
- style icon grid for a compact layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809a1452e88324ad06b008a3990023