### PR TITLE
Add Hydride segmentation upload and results view

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ With the services running you should get a JSON status from:
 curl http://localhost:5000/health
 ```
 
+The hydride segmentation tool is available at `/hydride_segmentation`.
+Upload an image and choose either the ML or conventional algorithm. Results
+include the segmentation mask, overlay and orientation analysis.
+
 ## Repository layout
 
 ```

--- a/src/ml_server/app/routes/hydride_segmentation.py
+++ b/src/ml_server/app/routes/hydride_segmentation.py
@@ -1,16 +1,24 @@
-import base64
-
-from flask import Blueprint, jsonify, render_template, request
-
 """Routes handling hydride segmentation requests."""
 
+from __future__ import annotations
+
+import base64
+import io
+
+from flask import Blueprint, current_app, render_template, request
+from PIL import Image
+
 from ...config import Config
-from ..services.hydride_segmentation import HydrideSegmentationService
 from ..services.utils import allowed_file
 
 bp = Blueprint("hydride_segmentation", __name__)
 config = Config()
-service = HydrideSegmentationService(config)
+
+
+def _to_b64(image: Image.Image) -> str:
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
 
 
 @bp.route("/hydride_segmentation", methods=["GET", "POST"])
@@ -18,36 +26,67 @@ def hydride_segmentation():
     """Run hydride segmentation on an uploaded image."""
     if request.method == "POST":
         if "image" not in request.files:
-            return jsonify({"success": False, "error": "No image uploaded"}), 400
+            return (
+                render_template("hydride_segmentation.html", error="No image uploaded"),
+                400,
+            )
 
         file = request.files["image"]
         if file.filename == "":
-            return jsonify({"success": False, "error": "No image selected"}), 400
-
-        allowed_exts = config.hydride_segmentation_settings.get("allowed_extensions", [])
-        if not allowed_file(file.filename, allowed_exts):
-            return jsonify({"success": False, "error": "Invalid file type"}), 400
-
-        if not service.is_available():
             return (
-                jsonify({"success": False, "error": "Hydride model is not running"}),
-                503,
+                render_template("hydride_segmentation.html", error="No image selected"),
+                400,
+            )
+
+        allowed_exts = config.hydride_segmentation_settings.get(
+            "allowed_extensions", []
+        )
+        if not allowed_file(file.filename, allowed_exts):
+            return (
+                render_template("hydride_segmentation.html", error="Invalid file type"),
+                400,
             )
 
         try:
-            result = service.segment(file)
-            file.seek(0)
-            original_b64 = base64.b64encode(file.read()).decode()
-            segmented_b64 = base64.b64encode(result).decode()
-            return jsonify(
-                {
-                    "success": True,
-                    "original_image": f"data:image/png;base64,{original_b64}",
-                    "segmented_image": f"data:image/png;base64,{segmented_b64}",
-                }
+            from hydride_segmentation_api import segment_hydride_image
+        except ImportError:
+            return (
+                render_template(
+                    "hydride_segmentation.html",
+                    error="Segmentation library not installed",
+                ),
+                500,
             )
-        except Exception as e:
-            bp.logger.error(f"Hydride segmentation error: {e}")
-            return jsonify({"success": False, "error": str(e)}), 500
+
+        algorithm = request.form.get("algorithm", "ml")
+        params = {}
+        if algorithm == "conventional":
+            try:
+                params["area_threshold"] = int(request.form.get("area_threshold", "95"))
+                params["tile_size"] = int(request.form.get("tile_size", "8"))
+            except ValueError:
+                return (
+                    render_template(
+                        "hydride_segmentation.html", error="Invalid parameter values"
+                    ),
+                    400,
+                )
+
+        try:
+            img = Image.open(file.stream).convert("RGB")
+            result = segment_hydride_image(img, model=algorithm, params=params)
+        except Exception as e:  # noqa: BLE001
+            current_app.logger.error(f"Hydride segmentation error: {e}")
+            return (
+                render_template(
+                    "hydride_segmentation.html", error="Segmentation failed"
+                ),
+                500,
+            )
+
+        images = {
+            name: f"data:image/png;base64,{_to_b64(im)}" for name, im in result.items()
+        }
+        return render_template("hydride_results.html", images=images)
 
     return render_template("hydride_segmentation.html")

--- a/src/ml_server/templates/home.html
+++ b/src/ml_server/templates/home.html
@@ -18,6 +18,35 @@
         </a>
     </div>
 
+    <div class="mt-5">
+        <h2>Quick Hydride Segmentation</h2>
+        <form action="{{ url_for('hydride_segmentation.hydride_segmentation') }}" method="post" enctype="multipart/form-data">
+            <div class="mb-3">
+                <input type="file" name="image" class="form-control" accept="image/*" required>
+            </div>
+            <div class="mb-3">
+                <select name="algorithm" id="home-algorithm" class="form-select">
+                    <option value="ml">ML</option>
+                    <option value="conventional">Conventional</option>
+                </select>
+            </div>
+            <div id="home-conv" class="mb-3" style="display:none;">
+                <input class="form-control mb-2" type="number" name="area_threshold" value="95" placeholder="Area Threshold">
+                <input class="form-control" type="number" name="tile_size" value="8" placeholder="Tile Size">
+            </div>
+            <button class="btn btn-primary" type="submit">Segment</button>
+        </form>
+        <script nonce="{{ csp_nonce() }}">
+        (function(){
+            const sel=document.getElementById('home-algorithm');
+            const div=document.getElementById('home-conv');
+            function toggle(){div.style.display=sel.value==='conventional'?'block':'none';}
+            sel.addEventListener('change',toggle);
+            toggle();
+        })();
+        </script>
+    </div>
+
     <!-- About Section -->
     <div class="about-section mt-5" id="about">
         <h2 class="text-center mb-4">About</h2>

--- a/src/ml_server/templates/hydride_results.html
+++ b/src/ml_server/templates/hydride_results.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Hydride Segmentation Results{% endblock %}
+{% block content %}
+<h1 class="mb-4">Segmentation Results</h1>
+<div class="row row-cols-1 row-cols-md-3 g-4">
+  <div class="col text-center">
+    <img src="{{ images.original }}" class="img-fluid border" alt="Original">
+    <p class="mt-2">Original</p>
+  </div>
+  <div class="col text-center">
+    <img src="{{ images.mask }}" class="img-fluid border" alt="Mask">
+    <p class="mt-2">Mask</p>
+  </div>
+  <div class="col text-center">
+    <img src="{{ images.overlay }}" class="img-fluid border" alt="Overlay">
+    <p class="mt-2">Overlay</p>
+  </div>
+  <div class="col text-center">
+    <img src="{{ images.orientation }}" class="img-fluid border" alt="Orientation">
+    <p class="mt-2">Orientation Map</p>
+  </div>
+  <div class="col text-center">
+    <img src="{{ images.size_distribution }}" class="img-fluid border" alt="Distribution">
+    <p class="mt-2">Distribution Plot</p>
+  </div>
+  <div class="col text-center">
+    <img src="{{ images.angle_distribution }}" class="img-fluid border" alt="Angles">
+    <p class="mt-2">Angle Histogram</p>
+  </div>
+</div>
+{% endblock %}

--- a/src/ml_server/templates/hydride_segmentation.html
+++ b/src/ml_server/templates/hydride_segmentation.html
@@ -1,113 +1,39 @@
 {% extends "base.html" %}
-
-{% block title %}Hydride Segmentation - Microstructural Analysis{% endblock %}
-
+{% block title %}Hydride Segmentation{% endblock %}
 {% block content %}
-<div class="container-fluid px-0">
-    <div class="hero-section text-center py-5">
-        <div class="hero-background"></div>
-        <div class="hero-content position-relative">
-            <h1 class="display-4 fw-bold mb-3">Hydride Segmentation</h1>
-            <p class="lead mb-5">Identify hydrides in your microstructural images using advanced AI algorithms</p>
-            <div class="feature-badges d-flex justify-content-center gap-4 mb-4">
-                <div class="badge-item">
-                    <i class="bi bi-check-circle-fill text-success"></i>
-                    <span>Pixel-wise Segmentation</span>
-                </div>
-                <div class="badge-item">
-                    <i class="bi bi-check-circle-fill text-success"></i>
-                    <span>Overlay Visualization</span>
-                </div>
-                <div class="badge-item">
-                    <i class="bi bi-check-circle-fill text-success"></i>
-                    <span>Batch Processing</span>
-                </div>
-            </div>
-        </div>
+<h1 class="mb-4">Hydride Segmentation</h1>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label" for="image">Image</label>
+    <input type="file" class="form-control" id="image" name="image" accept="image/*" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label" for="algorithm">Algorithm</label>
+    <select class="form-select" id="algorithm" name="algorithm">
+      <option value="ml">ML</option>
+      <option value="conventional">Conventional</option>
+    </select>
+  </div>
+  <div id="conv-params" style="display:none;">
+    <div class="mb-3">
+      <label class="form-label" for="area_threshold">Area Threshold</label>
+      <input class="form-control" type="number" id="area_threshold" name="area_threshold" value="95">
     </div>
-
-    <div class="main-content">
-        <div class="upload-section py-5">
-            <div class="container">
-                <div class="row justify-content-center">
-                    <div class="col-lg-8">
-                        <div class="upload-container text-center p-5" id="dropZone">
-                            <div class="upload-icon mb-4">
-                                <i class="bi bi-cloud-arrow-up display-3"></i>
-                            </div>
-                            <h3 class="h4 mb-3">Upload Your Image</h3>
-                            <p class="text-muted mb-4">Drag and drop your image here, or click to browse</p>
-                            
-                            <form id="uploadForm" method="POST" enctype="multipart/form-data">
-                                <input type="file" id="fileInput" name="image" class="d-none" accept=".png,.jpg,.jpeg,.gif,.bmp,.tiff,.webp">
-                                <button type="button" class="btn btn-primary btn-lg px-5" id="browseBtn">
-                                    <i class="bi bi-folder me-2"></i>Browse File
-                                </button>
-                            </form>
-                            
-                            <div class="supported-formats mt-4">
-                                <div class="format-badge">
-                                    <i class="bi bi-file-earmark-image me-2"></i>
-                                    <span>Supported formats:</span>
-                                </div>
-                                <div class="format-list">
-                                    <span class="format-item">.png</span>
-                                    <span class="format-item">.jpg</span>
-                                    <span class="format-item">.jpeg</span>
-                                    <span class="format-item">.gif</span>
-                                    <span class="format-item">.bmp</span>
-                                    <span class="format-item">.tiff</span>
-                                    <span class="format-item">.webp</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- New Image Preview Section with Spinner -->
-        <div class="preview-section bg-light py-5 d-none" id="previewContainer">
-            <div class="container">
-                <div class="row justify-content-center">
-                    <div class="col-lg-10">
-
-                        <!-- Spinner -->
-                        <div id="loadingSpinner" style="display: none; text-align: center; margin: 20px;">
-                            <img src="/static/images/spinner.gif" alt="Loading..." width="50">
-                            <p>Processing image, please wait...</p>
-                        </div>
-
-                        <!-- Image Display -->
-                        <div class="image-container">
-                            <div class="original">
-                                <span class="label label-original">Original</span>
-                                <img id="originalImage" alt="Original Image" class="img-fluid" />
-                            </div>
-                            <div class="flipped">
-                                <span class="label label-flipped">Segmented</span>
-                                <img id="flippedImage" alt="Segmented Image" class="img-fluid" />
-                            </div>
-                        </div>
-
-                        <!-- Download Button -->
-                        <div class="text-center mt-4">
-                            <a id="downloadBtn" class="download-button" style="display:none;" download="segmented_image.png">
-                                ⬇️ Download Segmented Image
-                            </a>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="mb-3">
+      <label class="form-label" for="tile_size">Tile Size</label>
+      <input class="form-control" type="number" id="tile_size" name="tile_size" value="8">
     </div>
-</div>
-
-<!-- Include external CSS and JS files -->
-<link rel="stylesheet" href="{{ url_for('static', filename='css/hydride_segmentation.css') }}">
-<script src="{{ url_for('static', filename='js/hydride_segmentation.js') }}" nonce="{{ csp_nonce() }}"></script>
-
-<!-- Include Feedback Section -->
-{% include 'feedback_section.html' %}
+  </div>
+  {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+  <button class="btn btn-primary" type="submit">Run Segmentation</button>
+</form>
+<script nonce="{{ csp_nonce() }}">
+(function() {
+  const sel = document.getElementById('algorithm');
+  const params = document.getElementById('conv-params');
+  function toggle() { params.style.display = sel.value === 'conventional' ? 'block' : 'none'; }
+  sel.addEventListener('change', toggle);
+  toggle();
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- build new hydride segmentation route returning an HTML results page
- add quick form on the home page to upload images
- show algorithm parameters when `conventional` is chosen
- document the new endpoint in the README
- add templates for results display
- update tests for the new behaviour

## Testing
- `black src/ml_server/app/routes/hydride_segmentation.py tests/test_hydride_segmentation.py`
- `isort src/ml_server/app/routes/hydride_segmentation.py tests/test_hydride_segmentation.py`
- `flake8 src/ml_server/app/routes/hydride_segmentation.py tests/test_hydride_segmentation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c55bcdf48324b6cdebcc05a98271