### PR TITLE
Improve homepage and hydride segmentation UI

### DIFF
--- a/src/ml_server/static/css/hydride_segmentation.css
+++ b/src/ml_server/static/css/hydride_segmentation.css
@@ -13,7 +13,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-image: 
+    background-image:
         linear-gradient(45deg, rgba(26, 35, 126, 0.7) 0%, rgba(13, 71, 161, 0.7) 100%),
         url('data:image/svg+xml,<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"><rect width="60" height="60" fill="none"/><path d="M0 0L60 60M60 0L0 60" stroke="rgba(255,255,255,0.1)" stroke-width="1"/></svg>');
     background-size: cover, 30px 30px;
@@ -285,4 +285,19 @@
     .image-wrapper img {
         max-height: 300px;
     }
+}
+
+/* --------- Simple Drop Zone --------- */
+.drop-zone {
+    border: 2px dashed #cfd8dc;
+    border-radius: 12px;
+    padding: 2rem;
+    text-align: center;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s;
+}
+
+.drop-zone.dragover {
+    background-color: #f0f8ff;
+    border-color: #1a237e;
 }

--- a/src/ml_server/static/css/style.css
+++ b/src/ml_server/static/css/style.css
@@ -155,12 +155,6 @@ h1:after {
 }
 
 /* Icon Grid for Home Page */
-.icon-grid {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-}
 
 .icon-link {
     display: flex;
@@ -214,15 +208,15 @@ h1:after {
         padding-top: 1rem;
         padding-bottom: 1rem;
     }
-    
+
     .card-img-top {
         height: 220px; /* Even smaller on mobile */
     }
-    
+
     .navbar-brand {
         font-size: 1.2rem;
     }
-    
+
     h1 {
         font-size: 1.5rem;
     }
@@ -398,13 +392,13 @@ h1:after {
     .comparison-container {
         flex-direction: column;
     }
-    
+
     .original-side {
         border-right: none;
         border-bottom: 1px solid #dee2e6;
     }
-    
+
     .image-wrapper img {
         max-height: 300px;
     }
-} 
+}

--- a/src/ml_server/static/js/hydride_segmentation.js
+++ b/src/ml_server/static/js/hydride_segmentation.js
@@ -1,117 +1,55 @@
+// Simple drag-and-drop form handling for hydride segmentation
+
 document.addEventListener('DOMContentLoaded', function () {
-    const dropZone = document.getElementById('dropZone');
-    const fileInput = document.getElementById('fileInput');
-    const browseBtn = document.getElementById('browseBtn');
-    const uploadForm = document.getElementById('uploadForm');
+    const dropZone = document.getElementById('drop-zone');
+    const fileInput = document.getElementById('image');
+    const browseBtn = document.getElementById('browse-button');
+    const fileName = document.getElementById('file-name');
+    const algoSelect = document.getElementById('algorithm');
+    const convFields = document.getElementById('conv-fields');
 
-    const previewContainer = document.getElementById('previewContainer');
-    const originalImage = document.getElementById('originalImage');
-    const flippedImage = document.getElementById('flippedImage');
-    const downloadBtn = document.getElementById('downloadBtn');
-    const loadingSpinner = document.getElementById('loadingSpinner');
-
-    async function checkModelStatus() {
-        try {
-            const response = await fetch('/api/check_hydride_model_status');
-            const data = await response.json();
-            return data.running;
-        } catch (error) {
-            console.error('Error checking model status:', error);
-            return false;
-        }
+    if (!dropZone || !fileInput) {
+        return;
     }
 
-    async function handleFiles() {
-        const files = fileInput.files;
-        if (!files.length) return;
-
-        const file = files[0];
-        const validExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tiff', '.webp'];
-        const fileExtension = '.' + file.name.split('.').pop().toLowerCase();
-
-        if (!validExtensions.includes(fileExtension)) {
-            alert('Please upload a valid image file');
-            return;
-        }
-
-        // Show loading state immediately
-        previewContainer.classList.remove('d-none');
-        loadingSpinner.style.display = 'block';
-        downloadBtn.style.display = 'none';
-
-        try {
-            // Check if ML model is running
-            const modelRunning = await checkModelStatus();
-            if (!modelRunning) {
-                throw new Error('ML Model is not running. Please try again later.');
-            }
-
-            const formData = new FormData();
-            formData.append('image', file);
-
-            const response = await fetch('/hydride_segmentation', {
-                method: 'POST',
-                body: formData
-            });
-            
-            const data = await response.json();
-            
-            if (data.success) {
-                // Display both original and segmented images
-                originalImage.src = data.original_image;
-                flippedImage.src = data.segmented_image;
-                
-                // Show download button and set correct filename
-                downloadBtn.href = data.segmented_image;
-                downloadBtn.download = 'Segmented_' + file.name;
-                downloadBtn.style.display = 'inline-block';
-            } else {
-                throw new Error(data.error || 'Processing failed');
-            }
-        } catch (error) {
-            console.error('Error:', error);
-            alert(error.message || 'Error processing image. Please try again.');
-        } finally {
-            loadingSpinner.style.display = 'none';
-        }
-    }
-
-    fileInput.addEventListener('change', handleFiles);
     browseBtn.addEventListener('click', () => fileInput.click());
 
-    // Drag-and-drop support
-    ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-        dropZone.addEventListener(eventName, preventDefaults, false);
-        document.body.addEventListener(eventName, preventDefaults, false);
+    fileInput.addEventListener('change', updateFileName);
+
+    function updateFileName() {
+        if (fileInput.files.length) {
+            fileName.textContent = fileInput.files[0].name;
+        } else {
+            fileName.textContent = '';
+        }
+    }
+
+    ['dragenter', 'dragover'].forEach(evt => {
+        dropZone.addEventListener(evt, (e) => {
+            e.preventDefault();
+            dropZone.classList.add('dragover');
+        });
     });
 
-    function preventDefaults(e) {
+    ['dragleave', 'drop'].forEach(evt => {
+        dropZone.addEventListener(evt, (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('dragover');
+        });
+    });
+
+    dropZone.addEventListener('drop', (e) => {
         e.preventDefault();
-        e.stopPropagation();
-    }
-
-    ['dragenter', 'dragover'].forEach(eventName => {
-        dropZone.addEventListener(eventName, highlight, false);
+        if (e.dataTransfer.files.length) {
+            fileInput.files = e.dataTransfer.files;
+            updateFileName();
+        }
     });
 
-    ['dragleave', 'drop'].forEach(eventName => {
-        dropZone.addEventListener(eventName, unhighlight, false);
-    });
-
-    function highlight(e) {
-        dropZone.classList.add('dragover');
+    function toggleParams() {
+        convFields.style.display = algoSelect.value === 'conventional' ? 'block' : 'none';
     }
 
-    function unhighlight(e) {
-        dropZone.classList.remove('dragover');
-    }
-
-    dropZone.addEventListener('drop', handleDrop, false);
-
-    function handleDrop(e) {
-        const dt = e.dataTransfer;
-        const files = dt.files;
-        fileInput.files = files;
-        handleFiles();
-    }
+    algoSelect.addEventListener('change', toggleParams);
+    toggleParams();
 });

--- a/src/ml_server/templates/home.html
+++ b/src/ml_server/templates/home.html
@@ -7,45 +7,22 @@
     <h1 class="text-center mb-4">Microstructural Analysis Tools</h1>
 
     <!-- App Icon Grid -->
-    <div class="icon-grid">
-        <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="icon-link">
-            <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" alt="Hydride Segmentation" class="app-icon">
-            <span class="app-label">Hydride Segmentation</span>
-        </a>
-        <a href="{{ url_for('super_resolution.super_resolution') }}" class="icon-link">
-            <img src="{{ url_for('static', filename='images/SUPER_RES.PNG') }}" alt="Super-Resolution" class="app-icon">
-            <span class="app-label">Super-Resolution</span>
-        </a>
+    <div class="row justify-content-center g-4">
+        <div class="col-6 col-md-4 text-center">
+            <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
+                <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" alt="Hydride Segmentation" class="app-icon mb-2">
+                <span class="app-label">Hydride Segmentation</span>
+            </a>
+        </div>
+        <div class="col-6 col-md-4 text-center">
+            <a href="{{ url_for('super_resolution.super_resolution') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
+                <img src="{{ url_for('static', filename='images/SUPER_RES.PNG') }}" alt="Super-Resolution" class="app-icon mb-2">
+                <span class="app-label">Super-Resolution</span>
+            </a>
+        </div>
     </div>
 
-    <div class="mt-5">
-        <h2>Quick Hydride Segmentation</h2>
-        <form action="{{ url_for('hydride_segmentation.hydride_segmentation') }}" method="post" enctype="multipart/form-data">
-            <div class="mb-3">
-                <input type="file" name="image" class="form-control" accept="image/*" required>
-            </div>
-            <div class="mb-3">
-                <select name="algorithm" id="home-algorithm" class="form-select">
-                    <option value="ml">ML</option>
-                    <option value="conventional">Conventional</option>
-                </select>
-            </div>
-            <div id="home-conv" class="mb-3" style="display:none;">
-                <input class="form-control mb-2" type="number" name="area_threshold" value="95" placeholder="Area Threshold">
-                <input class="form-control" type="number" name="tile_size" value="8" placeholder="Tile Size">
-            </div>
-            <button class="btn btn-primary" type="submit">Segment</button>
-        </form>
-        <script nonce="{{ csp_nonce() }}">
-        (function(){
-            const sel=document.getElementById('home-algorithm');
-            const div=document.getElementById('home-conv');
-            function toggle(){div.style.display=sel.value==='conventional'?'block':'none';}
-            sel.addEventListener('change',toggle);
-            toggle();
-        })();
-        </script>
-    </div>
+
 
     <!-- About Section -->
     <div class="about-section mt-5" id="about">

--- a/src/ml_server/templates/hydride_segmentation.html
+++ b/src/ml_server/templates/hydride_segmentation.html
@@ -1,39 +1,48 @@
 {% extends "base.html" %}
 {% block title %}Hydride Segmentation{% endblock %}
 {% block content %}
-<h1 class="mb-4">Hydride Segmentation</h1>
-<form method="post" enctype="multipart/form-data">
-  <div class="mb-3">
-    <label class="form-label" for="image">Image</label>
-    <input type="file" class="form-control" id="image" name="image" accept="image/*" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label" for="algorithm">Algorithm</label>
-    <select class="form-select" id="algorithm" name="algorithm">
-      <option value="ml">ML</option>
-      <option value="conventional">Conventional</option>
-    </select>
-  </div>
-  <div id="conv-params" style="display:none;">
-    <div class="mb-3">
-      <label class="form-label" for="area_threshold">Area Threshold</label>
-      <input class="form-control" type="number" id="area_threshold" name="area_threshold" value="95">
+<div class="container">
+    <h1 class="text-center mb-4">Hydride Segmentation</h1>
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+            <form id="segmentForm" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <label for="image" class="form-label">Image</label>
+                    <div id="drop-zone" class="drop-zone">
+                        <p class="text-muted mb-2">Drag and drop an image here or click to browse</p>
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="browse-button">Browse</button>
+                        <input type="file" id="image" name="image" class="d-none" accept="image/*" required>
+                        <div id="file-name" class="form-text"></div>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label for="algorithm" class="form-label">Algorithm</label>
+                    <select id="algorithm" name="algorithm" class="form-select">
+                        <option value="ml">ML</option>
+                        <option value="conventional" selected>Conventional</option>
+                    </select>
+                </div>
+                <div id="conv-fields">
+                    <div class="mb-3">
+                        <label for="area_threshold" class="form-label">Area Threshold</label>
+                        <input type="number" id="area_threshold" name="area_threshold" class="form-control" value="95">
+                        <div class="form-text">Minimum hydride area to keep.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="tile_size" class="form-label">Tile Size</label>
+                        <input type="number" id="tile_size" name="tile_size" class="form-control" value="8">
+                        <div class="form-text">Size of tiles used during processing.</div>
+                    </div>
+                </div>
+                {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+                <div class="text-end">
+                    <button type="reset" class="btn btn-secondary me-2">Reset</button>
+                    <button type="submit" class="btn btn-primary">Run Segmentation</button>
+                </div>
+            </form>
+        </div>
     </div>
-    <div class="mb-3">
-      <label class="form-label" for="tile_size">Tile Size</label>
-      <input class="form-control" type="number" id="tile_size" name="tile_size" value="8">
-    </div>
-  </div>
-  {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-  <button class="btn btn-primary" type="submit">Run Segmentation</button>
-</form>
-<script nonce="{{ csp_nonce() }}">
-(function() {
-  const sel = document.getElementById('algorithm');
-  const params = document.getElementById('conv-params');
-  function toggle() { params.style.display = sel.value === 'conventional' ? 'block' : 'none'; }
-  sel.addEventListener('change', toggle);
-  toggle();
-})();
-</script>
+</div>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/hydride_segmentation.css') }}">
+<script src="{{ url_for('static', filename='js/hydride_segmentation.js') }}" nonce="{{ csp_nonce() }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove quick hydride form from homepage and fix icon layout
- redesign hydride segmentation page with drag-drop upload and conditional options
- add supporting JS and CSS
- style updates for icon grid and new drop-zone

## Testing
- `pre-commit run --files src/ml_server/static/css/style.css src/ml_server/templates/home.html src/ml_server/templates/hydride_segmentation.html src/ml_server/static/css/hydride_segmentation.css src/ml_server/static/js/hydride_segmentation.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cd03040083249588dca76bfe5d4a