### PR TITLE
Integrate PDF tools and update UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,11 @@ maintainable, please follow these rules:
    - Do not commit binary or model files (`*.pkl`, `*.h5`, `*.pt`, etc.).
    - Large data artifacts should be excluded via `.gitignore`.
 
+### PDF Tools
+
+The PDF merging and extraction utilities originate from a separate internal
+repository. When modifying these tools, keep the code in
+`ml_server/app/services/pdf_tools` in sync with the upstream project. Tests for
+PDF functionality should accompany any changes.
+
 Happy coding!

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The hydride segmentation tool is available at `/hydride_segmentation`.
 Upload an image and choose either the ML or conventional algorithm. Results
 include the segmentation mask, overlay and orientation analysis.
 
+## PDF Tools
+
+Navigate to `/pdf_tools` for secure PDF utilities. The page offers merging of
+multiple PDFs and extraction of specific page ranges. All operations run within
+the intranet and no files are stored on disk, ensuring privacy.
+
 ## Repository layout
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,7 @@ The application is composed of a Flask web layer and separate model services.
 - **Model Services** – Stub servers in `scripts/` emulate ML models. Real models can be dropped in with the same interface.
 - **Celery Worker** – Processes long running tasks and communicates with Redis.
 - **Docker Compose** – Provides Redis, workers and the web server for local development.
+- **PDF Tools** – Lightweight utilities for merging and extracting pages from PDFs. They run entirely within the Flask app.
 
 The app loads configuration from `config/config.intranet.json` and environment variables via a lightweight loader in `ml_server.config`.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,7 +20,7 @@ This document describes a recommended process for deploying the microstructural 
    ```
 
 ## 2. Install Dependencies
-Install all Python dependencies from `requirements.txt` and testing utilities if needed:
+Install all Python dependencies from `requirements.txt` and testing utilities if needed. The PDF tools require `PyPDF2` and `pdf2image`, which are included in the requirements file:
 ```bash
 pip install -r requirements.txt
 # Optional: install test utilities

--- a/docs/WORKFLOW_OVERVIEW.md
+++ b/docs/WORKFLOW_OVERVIEW.md
@@ -19,5 +19,6 @@ workers communicating through Redis queues.
 - **celery_app** – defines the Celery instance and tasks
 - **routes/** – HTTP endpoints for the web UI and API
 - **services/** – helpers and utilities used by the routes
+- **pdf_tools/** – merge and extract page utilities integrated from the companion repository
 
 The `health` endpoint aggregates the status of Redis, Celery and model services.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
     "gunicorn==21.2.0",
     "Flask-Compress==1.14",
     "Flask-Talisman==1.1.0",
-    "prometheus-client==0.20.0"
+    "prometheus-client==0.20.0",
+    "PyPDF2",
+    "pdf2image"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ gunicorn==21.2.0
 Flask-Compress==1.14
 Flask-Talisman==1.1.0
 prometheus-client==0.20.0
+PyPDF2
+pdf2image

--- a/src/ml_server/app/routes/pdf_tools.py
+++ b/src/ml_server/app/routes/pdf_tools.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from flask import Blueprint, jsonify, render_template, request, send_file
+
+from ..services.pdf_tools.merge_service import MergeService
+from ..services.pdf_tools.extract_service import ExtractService
+
+bp = Blueprint("pdf_tools", __name__, url_prefix="/pdf_tools")
+merge_service = MergeService()
+extract_service = ExtractService()
+
+
+@bp.route("/")
+def pdf_tools_home():
+    """Landing page for PDF utilities."""
+    return render_template("pdf_tools.html")
+
+
+@bp.route("/merge", methods=["GET", "POST"])
+def merge_pdfs():
+    """Merge multiple PDF files."""
+    if request.method == "POST":
+        files = [(BytesIO(f.read()), "all") for f in request.files.getlist("files")]
+        if not files:
+            return (
+                jsonify({"success": False, "error": "No files uploaded"}),
+                400,
+            )
+        try:
+            output = merge_service.process(files)
+            return send_file(
+                output,
+                as_attachment=True,
+                download_name=merge_service.output_name,
+                mimetype="application/pdf",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return jsonify({"success": False, "error": str(exc)}), 400
+    return render_template("merge_pdfs.html")
+
+
+@bp.route("/extract", methods=["GET", "POST"])
+def extract_from_pdf():
+    """Extract pages from a PDF file."""
+    if request.method == "POST":
+        file = request.files.get("file")
+        if not file:
+            return jsonify({"success": False, "error": "No file uploaded"}), 400
+        range_str = request.form.get("range", "all")
+        try:
+            output = extract_service.process(BytesIO(file.read()), range_str)
+            return send_file(
+                output,
+                as_attachment=True,
+                download_name="extracted.pdf",
+                mimetype="application/pdf",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return jsonify({"success": False, "error": str(exc)}), 400
+    return render_template("extract_from_pdf.html")

--- a/src/ml_server/app/server.py
+++ b/src/ml_server/app/server.py
@@ -49,6 +49,7 @@ def create_app(startup: bool = True) -> Flask:
     from .routes.feedback import bp as feedback_bp
     from .routes.hydride_segmentation import bp as hydride_bp
     from .routes.main import bp as main_bp
+    from .routes.pdf_tools import bp as pdf_tools_bp
     from .routes.super_resolution import bp as super_res_bp
 
     app.register_blueprint(main_bp)
@@ -56,6 +57,7 @@ def create_app(startup: bool = True) -> Flask:
     app.register_blueprint(super_res_bp)
     app.register_blueprint(ebsd_bp)
     app.register_blueprint(hydride_bp)
+    app.register_blueprint(pdf_tools_bp)
     app.register_blueprint(api_bp)
     app.register_blueprint(download_bp)
 

--- a/src/ml_server/app/services/pdf_tools/base.py
+++ b/src/ml_server/app/services/pdf_tools/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from io import BytesIO
+
+
+class PDFService(ABC):
+    """Base service defining interface for PDF operations."""
+
+    @abstractmethod
+    def process(self, *args, **kwargs) -> BytesIO:
+        """Process input PDF(s) and return a BytesIO of the result."""
+        raise NotImplementedError

--- a/src/ml_server/app/services/pdf_tools/extract_service.py
+++ b/src/ml_server/app/services/pdf_tools/extract_service.py
@@ -1,0 +1,65 @@
+from io import BytesIO
+from typing import List
+
+from PyPDF2 import PdfReader, PdfWriter
+from pdf2image import convert_from_bytes
+from pdf2image.pdf2image import PDFInfoNotInstalledError
+from PIL import Image
+
+from .base import PDFService
+from ml_server.app.utils.pdf_tools.pdf_parser import PDFPageParser
+
+
+class ExtractService(PDFService):
+    """Service to extract pages from a PDF."""
+
+    def process(
+        self,
+        file_stream: BytesIO,
+        range_str: str,
+        *,
+        as_images: bool = False,
+        preview: bool = False,
+    ) -> BytesIO | List[BytesIO]:
+        """Extract a range of pages from ``file_stream``.
+
+        Parameters
+        ----------
+        as_images:
+            When ``True`` return list of PNG images instead of a PDF.
+        preview:
+            When ``True`` populate ``self.preview_images`` with PNG images of
+            the extracted pages.
+        """
+
+        reader = PdfReader(file_stream)
+        parser = PDFPageParser()
+        pages = parser.parse(range_str, len(reader.pages))
+        self.preview_images = []
+
+        if as_images or preview:
+            images: List[BytesIO] = []
+            for page_num in pages:
+                try:
+                    img = convert_from_bytes(
+                        file_stream.getvalue(), first_page=page_num, last_page=page_num
+                    )[0]
+                except (PDFInfoNotInstalledError, OSError):
+                    img = Image.new("RGB", (200, 200), color="white")
+                buf = BytesIO()
+                img.save(buf, format="PNG")
+                buf.seek(0)
+                if as_images:
+                    images.append(BytesIO(buf.getvalue()))
+                self.preview_images.append(BytesIO(buf.getvalue()))
+            if as_images:
+                return images
+
+        writer = PdfWriter()
+        for page_num in pages:
+            writer.add_page(reader.pages[page_num - 1])
+
+        output = BytesIO()
+        writer.write(output)
+        output.seek(0)
+        return output

--- a/src/ml_server/app/services/pdf_tools/merge_service.py
+++ b/src/ml_server/app/services/pdf_tools/merge_service.py
@@ -1,0 +1,44 @@
+from io import BytesIO
+from typing import Iterable, Tuple, List, Optional
+
+from PyPDF2 import PdfReader, PdfWriter
+
+from .base import PDFService
+from ml_server.app.utils.pdf_tools.pdf_parser import PDFPageParser
+
+
+class MergeService(PDFService):
+    """Service to merge PDF files."""
+
+    def process(
+        self,
+        files: Iterable[Tuple[BytesIO, str]],
+        order: Optional[List[int]] | None = None,
+        output_name: str | None = None,
+    ) -> BytesIO:
+        """Merge PDFs into a single stream.
+
+        Parameters
+        ----------
+        files:
+            Iterable of ``(BytesIO, range_str)`` pairs where ``range_str``
+            denotes the user-supplied page range.
+        """
+
+        writer = PdfWriter()
+        parser = PDFPageParser()
+        file_list = list(files)
+        if order:
+            file_list = [file_list[i] for i in order]
+
+        for file_stream, range_str in file_list:
+            reader = PdfReader(file_stream)
+            pages = parser.parse(range_str, len(reader.pages))
+            for page_num in pages:
+                writer.add_page(reader.pages[page_num - 1])
+
+        output = BytesIO()
+        writer.write(output)
+        output.seek(0)
+        self.output_name = output_name or "merged.pdf"
+        return output

--- a/src/ml_server/app/utils/pdf_tools/pdf_parser.py
+++ b/src/ml_server/app/utils/pdf_tools/pdf_parser.py
@@ -1,0 +1,34 @@
+"""Utility for parsing page range strings."""
+
+import re
+from typing import List
+
+
+class PDFPageParser:
+    """Parse user-supplied page ranges."""
+
+    RANGE_RE = re.compile(r"^(\d+(?:-\d+)?)(,\d+(?:-\d+)?)*$", re.ASCII)
+
+    def parse(self, range_str: str, total_pages: int) -> List[int]:
+        """Return a list of page numbers from a range string."""
+
+        if not range_str or range_str.lower() == "all":
+            return list(range(1, total_pages + 1))
+
+        if not self.RANGE_RE.match(range_str.replace(' ', '')):
+            raise ValueError("Invalid range format")
+
+        pages = []
+        for part in range_str.split(','):
+            part = part.strip()
+            if '-' in part:
+                start, end = map(int, part.split('-', 1))
+                if start < 1 or end > total_pages or start > end:
+                    raise ValueError("Invalid page range")
+                pages.extend(range(start, end + 1))
+            else:
+                num = int(part)
+                if num < 1 or num > total_pages:
+                    raise ValueError("Page number out of range")
+                pages.append(num)
+        return pages

--- a/src/ml_server/static/js/pdf_tools.js
+++ b/src/ml_server/static/js/pdf_tools.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const filesDiv = document.getElementById('files');
+    const addBtn = document.getElementById('add-file');
+
+    function addFileInput() {
+        const idx = filesDiv.children.length;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'file-item';
+        wrapper.innerHTML = `<input type="file" name="file${idx}" required>
+            <input type="text" name="range_file${idx}" value="all" placeholder="Page range">
+            <button type="button" class="up">&#8593;</button>
+            <button type="button" class="down">&#8595;</button>`;
+        filesDiv.appendChild(wrapper);
+    }
+
+    if (addBtn) {
+        addBtn.addEventListener('click', addFileInput);
+        addFileInput();
+    }
+
+    filesDiv.addEventListener('click', (e) => {
+        const item = e.target.closest('.file-item');
+        if (!item) return;
+        if (e.target.classList.contains('up') && item.previousElementSibling) {
+            filesDiv.insertBefore(item, item.previousElementSibling);
+        } else if (e.target.classList.contains('down') && item.nextElementSibling) {
+            filesDiv.insertBefore(item.nextElementSibling, item);
+        }
+    });
+
+    document.getElementById('merge-form')?.addEventListener('submit', () => {
+        const order = [];
+        Array.from(filesDiv.children).forEach((item, idx) => {
+            const fileInput = item.querySelector('input[type="file"]');
+            const rangeInput = item.querySelector('input[type="text"]');
+            fileInput.name = `file${idx}`;
+            rangeInput.name = `range_file${idx}`;
+            order.push(idx);
+        });
+        const orderField = document.createElement('input');
+        orderField.type = 'hidden';
+        orderField.name = 'order';
+        orderField.value = order.join(',');
+        document.getElementById('merge-form').appendChild(orderField);
+    });
+});

--- a/src/ml_server/templates/base.html
+++ b/src/ml_server/templates/base.html
@@ -4,13 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Microstructural Analysis - {% block title %}{% endblock %}</title>
+    <link rel="icon" href="{{ url_for('static', filename='images/ml_server_icon.png') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='vendor/bootstrap/bootstrap.min.css') }}">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" href="{{ url_for('main.home') }}">
-                <span class='me-2'><svg class='bi' width='16' height='16'><use href='{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.svg') }}#atom'></use></svg></span>
+                <img src="{{ url_for('static', filename='images/ml_server_icon.png') }}" alt="ML Server" width="32" height="32" class="me-2">
                 Microstructural Analysis
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">

--- a/src/ml_server/templates/extract_from_pdf.html
+++ b/src/ml_server/templates/extract_from_pdf.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block title %}Extract Pages{% endblock %}
+{% block content %}
+<div class="container">
+    <h1 class="text-center mb-4">Extract Pages</h1>
+    <form method="post" enctype="multipart/form-data" class="text-center">
+        <div class="mb-3">
+            <input type="file" name="file" required class="form-control" accept="application/pdf">
+        </div>
+        <div class="mb-3">
+            <input type="text" name="range" placeholder="1-3" class="form-control" title="Pages to extract">
+        </div>
+        <button type="submit" class="btn btn-primary">Extract</button>
+    </form>
+</div>
+{% endblock %}

--- a/src/ml_server/templates/home.html
+++ b/src/ml_server/templates/home.html
@@ -10,7 +10,7 @@
     <div class="row justify-content-center g-4">
         <div class="col-6 col-md-4 text-center">
             <a href="{{ url_for('hydride_segmentation.hydride_segmentation') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
-                <img src="{{ url_for('static', filename='images/hydride_icon.svg') }}" alt="Hydride Segmentation" class="app-icon mb-2">
+                <img src="{{ url_for('static', filename='images/hydride_icon.png') }}" alt="Hydride Segmentation" class="app-icon mb-2">
                 <span class="app-label">Hydride Segmentation</span>
             </a>
         </div>
@@ -18,6 +18,12 @@
             <a href="{{ url_for('super_resolution.super_resolution') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
                 <img src="{{ url_for('static', filename='images/SUPER_RES.PNG') }}" alt="Super-Resolution" class="app-icon mb-2">
                 <span class="app-label">Super-Resolution</span>
+            </a>
+        </div>
+        <div class="col-6 col-md-4 text-center">
+            <a href="{{ url_for('pdf_tools.pdf_tools_home') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
+                <img src="{{ url_for('static', filename='images/pdf_tools.png') }}" alt="PDF Tools" class="app-icon mb-2">
+                <span class="app-label">PDF Tools</span>
             </a>
         </div>
     </div>

--- a/src/ml_server/templates/merge_pdfs.html
+++ b/src/ml_server/templates/merge_pdfs.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Merge PDFs{% endblock %}
+{% block content %}
+<div class="container">
+    <h1 class="text-center mb-4">Merge PDFs</h1>
+    <form method="post" enctype="multipart/form-data" class="text-center">
+        <div class="mb-3">
+            <input type="file" name="files" multiple required class="form-control" accept="application/pdf">
+        </div>
+        <button type="submit" class="btn btn-primary">Merge</button>
+    </form>
+</div>
+<script src="{{ url_for('static', filename='js/pdf_tools.js') }}" nonce="{{ csp_nonce() }}"></script>
+{% endblock %}

--- a/src/ml_server/templates/pdf_tools.html
+++ b/src/ml_server/templates/pdf_tools.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}PDF Tools{% endblock %}
+{% block content %}
+<div class="container text-center">
+    <h1 class="mb-4">Welcome to PDF Utilities</h1>
+    <p class="mb-5">This secure internal utility offers two convenient tools: PDF merging and selective page extraction. All operations are performed securely within the intranet. No files are stored, ensuring complete data privacy and security.</p>
+    <div class="row justify-content-center g-4">
+        <div class="col-6 col-md-4 text-center">
+            <a href="{{ url_for('pdf_tools.merge_pdfs') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
+                <img src="{{ url_for('static', filename='images/merge_pdfs_icon.png') }}" alt="Merge PDFs" class="app-icon mb-2">
+                <span class="app-label">Merge PDFs</span>
+            </a>
+        </div>
+        <div class="col-6 col-md-4 text-center">
+            <a href="{{ url_for('pdf_tools.extract_from_pdf') }}" class="icon-link d-inline-flex flex-column align-items-center w-100">
+                <img src="{{ url_for('static', filename='images/extract_from_pdf_icon.png') }}" alt="Extract Pages" class="app-icon mb-2">
+                <span class="app-label">Extract Pages</span>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_pdf_tools_routes.py
+++ b/tests/test_pdf_tools_routes.py
@@ -1,0 +1,32 @@
+from io import BytesIO
+from PyPDF2 import PdfWriter
+
+def _make_pdf(pages: int = 1) -> bytes:
+    writer = PdfWriter()
+    for _ in range(pages):
+        writer.add_blank_page(width=72, height=72)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    return buf.read()
+
+
+def test_pdf_tools_home(client):
+    resp = client.get("/pdf_tools/")
+    assert resp.status_code == 200
+
+
+def test_merge_endpoint(client):
+    pdf = _make_pdf()
+    data = {"files": [(BytesIO(pdf), "a.pdf"), (BytesIO(pdf), "b.pdf")]}
+    resp = client.post("/pdf_tools/merge", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/pdf"
+
+
+def test_extract_endpoint(client):
+    pdf = _make_pdf(2)
+    data = {"file": (BytesIO(pdf), "test.pdf"), "range": "1"}
+    resp = client.post("/pdf_tools/extract", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/pdf"


### PR DESCRIPTION
## Summary
- add new PDF utilities blueprint and routes
- include PDF merge and extract templates and JS
- update home page icons and use png hydride icon
- show ml_server icon globally and add favicon
- document PDF tools usage and contribution notes
- extend architecture and deployment docs
- add unit tests for PDF tools
- remove large placeholder pdf_tools icon

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881ec602b548324a0ec96819ca2eac1