### PR TITLE
Improve PDF merge tool preview and page range input

### DIFF
--- a/src/ml_server/static/css/style.css
+++ b/src/ml_server/static/css/style.css
@@ -375,6 +375,28 @@ h1:after {
     object-fit: contain;
 }
 
+.pdf-item {
+    display: inline-block;
+    margin: 0.25rem;
+}
+
+.pdf-preview {
+    width: 200px;
+    height: 200px;
+    object-fit: contain;
+    border: 1px solid var(--border-color);
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.range-input {
+    max-width: 200px;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+}
+
 /* Hide slider elements */
 .slider-handle, .handle-line, .handle-circle, .handle-arrows {
     display: none !important;

--- a/src/ml_server/static/js/pdf_tools.js
+++ b/src/ml_server/static/js/pdf_tools.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const status = document.getElementById('mergeStatus');
     const placeholder = '/static/images/preview_unavailable.svg';
 
+    const PREVIEW_SIZE = 200;
+
     function createItem(input) {
         const div = document.createElement('div');
         div.className = 'pdf-item card p-2 mb-2';
@@ -14,8 +16,15 @@ document.addEventListener('DOMContentLoaded', () => {
         canvas.className = 'pdf-preview mb-1';
         div.appendChild(canvas);
         const info = document.createElement('div');
-        info.className = 'small text-center';
+        info.className = 'small text-center mb-1';
         div.appendChild(info);
+
+        const range = document.createElement('input');
+        range.type = 'text';
+        range.value = 'all';
+        range.placeholder = 'pages e.g. 1-3,5';
+        range.className = 'form-control form-control-sm range-input mb-1';
+        div.appendChild(range);
 
         list.appendChild(div);
 
@@ -25,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const pdf = await pdfjsLib.getDocument({data: e.target.result}).promise;
                 const page = await pdf.getPage(1);
                 const viewport = page.getViewport({scale: 1});
-                const scale = 100 / viewport.height;
+                const scale = PREVIEW_SIZE / viewport.height;
                 const v = page.getViewport({scale});
                 canvas.width = v.width;
                 canvas.height = v.height;
@@ -46,7 +55,6 @@ document.addEventListener('DOMContentLoaded', () => {
         addBtn.addEventListener('click', () => {
             const input = document.createElement('input');
             input.type = 'file';
-            input.name = 'files';
             input.accept = 'application/pdf';
             input.classList.add('d-none');
             input.addEventListener('change', () => input.files.length && createItem(input));
@@ -60,6 +68,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     form?.addEventListener('submit', () => {
+        Array.from(list.children).forEach((item, idx) => {
+            item.querySelector('input[type="file"]').name = `file${idx}`;
+            item.querySelector('.range-input').name = `range_file${idx}`;
+        });
+        const orderField = document.createElement('input');
+        orderField.type = 'hidden';
+        orderField.name = 'order';
+        orderField.value = Array.from(list.children).map((_, i) => i).join(',');
+        form.appendChild(orderField);
+
         if (status) {
             status.textContent = '🔄 Please wait while your PDF files are being merged…';
         }

--- a/src/ml_server/templates/merge_pdfs.html
+++ b/src/ml_server/templates/merge_pdfs.html
@@ -8,6 +8,10 @@
     <form id="mergeForm" method="post" enctype="multipart/form-data" class="text-center">
         <div id="fileList" class="mb-3"></div>
         <button type="button" id="addFileBtn" class="btn btn-secondary mb-3">Add File</button>
+        <div class="mb-3 small text-muted">Enter page numbers like "1-3,5" or leave as "all".</div>
+        <div class="mb-3">
+            <input type="text" class="form-control text-center" name="output_name" value="merged.pdf" placeholder="Output filename">
+        </div>
         <div id="mergeStatus" class="mb-3 text-muted"></div>
         <button type="submit" class="btn btn-primary">Merge</button>
     </form>

--- a/tests/test_pdf_tools_routes.py
+++ b/tests/test_pdf_tools_routes.py
@@ -1,5 +1,7 @@
 from io import BytesIO
+
 from PyPDF2 import PdfWriter
+
 
 def _make_pdf(pages: int = 1) -> bytes:
     writer = PdfWriter()
@@ -18,7 +20,13 @@ def test_pdf_tools_home(client):
 
 def test_merge_endpoint(client):
     pdf = _make_pdf()
-    data = {"files": [(BytesIO(pdf), "a.pdf"), (BytesIO(pdf), "b.pdf")]}
+    data = {
+        "file0": (BytesIO(pdf), "a.pdf"),
+        "range_file0": "all",
+        "file1": (BytesIO(pdf), "b.pdf"),
+        "range_file1": "all",
+        "order": "0,1",
+    }
     resp = client.post("/pdf_tools/merge", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
     assert resp.mimetype == "application/pdf"


### PR DESCRIPTION
## Summary
- allow specifying page ranges per file when merging PDFs
- show smaller 200x200 preview thumbnails
- add output filename field and hint text
- update tests for new API

## Testing
- `pre-commit run --files src/ml_server/app/routes/pdf_tools.py src/ml_server/static/js/pdf_tools.js src/ml_server/static/css/style.css src/ml_server/templates/merge_pdfs.html tests/test_pdf_tools_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882140cc9088324b5171ba9608495b5