### PR TITLE
Improve admin dashboard UI and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,5 +40,7 @@ New routes should record request metrics using the helpers in
 `ml_server.app.services.metrics`. If you add admin pages, register them with the
 Flask-Admin dashboard in `init_admin()`.
 
-Happy coding!
+When updating the dashboard UI, prefer lightweight libraries such as Chart.js
+via CDN links. Do not include binary assets or screenshots in the repository.
 
+Happy coding!

--- a/README.md
+++ b/README.md
@@ -45,17 +45,15 @@ the intranet and no files are stored on disk, ensuring privacy.
 
 ## Admin Dashboard and Monitoring
 
-An admin interface is available at `/admin`. Append `?token=<ADMIN_TOKEN>` to
-the URL to authenticate. The dashboard shows:
+Access the admin interface at `/admin?token=<ADMIN_TOKEN>`. The page now
+features a cleaner card layout and a bar chart visualising recent endpoint
+visits. Service health badges quickly indicate the status of background
+processes while logs and Prometheus metrics remain available in scrollable
+sections. These updates make it easier to monitor uptime, active users and
+system health at a glance.
 
-- Website usage statistics and active users
-- Stored user feedback
-- Health status of external services
-- Recent log entries
-- Live Prometheus metrics including CPU, memory and request latency
-
-Prometheus metrics are also exposed at `/metrics` for integration with external
-monitoring systems.
+Prometheus metrics continue to be exposed at `/metrics` for integration with
+external monitoring systems.
 
 ## Repository layout
 
@@ -82,8 +80,9 @@ Two keys control the size of icons displayed on the site:
 "toolsIconsSize": [75, 75]   # size of icons for individual tools
 ```
 
-These defaults can also be overridden via environment variables
-`APP_MAINICONSIZE` and `APP_TOOLSICONSSIZE` using JSON arrays like `[120,120]`.
+These values also control the logo in the navigation bar. Override them with the
+environment variables `APP_MAINICONSIZE` and `APP_TOOLSICONSSIZE` using JSON
+arrays like `[120,120]`.
 
 ## Development
 

--- a/src/ml_server/templates/admin_dashboard.html
+++ b/src/ml_server/templates/admin_dashboard.html
@@ -2,21 +2,73 @@
 {% block title %}Admin Dashboard{% endblock %}
 {% block content %}
 <h2 class="mb-4">Admin Dashboard</h2>
-<p><strong>Uptime:</strong> {{ uptime }}</p>
-<p><strong>Active users:</strong> {{ active_users }}</p>
-<h3>Website Visits</h3>
-<ul>
-  {% for ep, count in visits.items() %}
-  <li>{{ ep }}: {{ count }}</li>
-  {% endfor %}
-</ul>
-<h3>Service Health</h3>
-<pre>{{ health }}</pre>
+<div class="row g-4 mb-4">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Uptime</h5>
+                <p class="card-text">{{ uptime }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Active Users</h5>
+                <p class="card-text">{{ active_users }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Service Health</h5>
+                <ul class="list-unstyled mb-0">
+                {% for name, status in health.items() %}
+                    <li>
+                        <span class="badge {{ 'bg-success' if status else 'bg-danger' }}">{{ name }}</span>
+                    </li>
+                {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="mb-4">
+    <canvas id="visitChart" width="400" height="200"></canvas>
+</div>
+
 <h3>Recent Logs</h3>
-<pre>{{ logs }}</pre>
+<pre style="max-height: 300px; overflow-y: auto;">{{ logs }}</pre>
+
 <h3>User Feedback (latest 10)</h3>
 {% include "admin_feedback_table.html" %}
-<h3>Prometheus Metrics</h3>
-<pre>{{ metrics }}</pre>
-{% endblock %}
 
+<h3>Prometheus Metrics</h3>
+<pre style="max-height: 300px; overflow-y: auto;">{{ metrics }}</pre>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js" nonce="{{ csp_nonce() }}"></script>
+<script nonce="{{ csp_nonce() }}">
+    const visitData = {{ visits | tojson }};
+    const ctx = document.getElementById('visitChart');
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: Object.keys(visitData),
+            datasets: [{
+                label: 'Visits',
+                data: Object.values(visitData),
+                backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                borderColor: 'rgba(54, 162, 235, 1)',
+                borderWidth: 1
+            }]
+        },
+        options: {
+            scales: {
+                y: { beginAtZero: true }
+            }
+        }
+    });
+</script>
+{% endblock %}

--- a/src/ml_server/templates/base.html
+++ b/src/ml_server/templates/base.html
@@ -11,8 +11,9 @@
     <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" href="{{ url_for('main.home') }}">
-                <img src="{{ url_for('static', filename='images/ml_server_icon.png') }}" alt="ML Server" width="32" height="32" class="me-2">
-                Microstructural Analysis
+                <img src="{{ url_for('static', filename='images/ml_server_icon.png') }}" alt="ML Server"
+                     width="{{ config['MAIN_ICON_SIZE'][0] }}" height="{{ config['MAIN_ICON_SIZE'][1] }}" class="me-2">
+                <span class="fs-4">Microstructural Analysis</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
@@ -34,11 +35,6 @@
                             API Docs
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="https://github.com/kvmani/ml_server" target="_blank" rel="noopener noreferrer">
-                            GitHub
-                        </a>
-                    </li>
                 </ul>
             </div>
         </div>
@@ -46,20 +42,12 @@
 
     <div class="research-header py-4 bg-light border-bottom">
         <div class="container">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb mb-0">
-                            <li class="breadcrumb-item"><a href="{{ url_for('main.home') }}">Home</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">{% block breadcrumb_title %}{{ self.title() }}{% endblock %}</li>
-                        </ol>
-                    </nav>
-                </div>
-                <div class="research-badge">
-                    <svg class='bi me-1' width='16' height='16'><use href='{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.svg') }}#shield-check'/></svg>
-                    Research Portal
-                </div>
-            </div>
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ url_for('main.home') }}">Home</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">{% block breadcrumb_title %}{{ self.title() }}{% endblock %}</li>
+                </ol>
+            </nav>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- simplify navbar and use config for icon size
- add bar chart and cards to admin dashboard
- document new monitoring layout and icon sizing
- note recommended approach for dashboard UI in CONTRIBUTING

## Testing
- `pre-commit run --files src/ml_server/templates/base.html src/ml_server/templates/admin_dashboard.html README.md CONTRIBUTING.md`
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_6888630713ac8324b3a8ceeae4616044